### PR TITLE
Add watcher to newly created folders, when on fallback os

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 aemsync.zip
 npm-debug.log
 .idea
+*.iml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aemsync-weily",
-  "version": "1.3.0",
+  "version": "1.2.1",
   "description": "Adobe AEM Synchronization Tool",
   "author": "Michal Kochel <gavoja@gmail.com>, Willy Woitas, Matthias John <git@bitjo.de>",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,21 +1,18 @@
 {
   "name": "aemsync-weily",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Adobe AEM Synchronization Tool",
-  "author": "Michal Kochel <gavoja@gmail.com>, Willy Woitas",
+  "author": "Michal Kochel <gavoja@gmail.com>, Willy Woitas, Matthias John <git@bitjo.de>",
   "keywords": [
     "AEM",
     "CQ",
     "Sling",
     "Synchronization"
   ],
-  "homepage": "https://github.com/gavoja/aemsync",
-  "bugs": {
-    "url": "https://github.com/gavoja/aemsync/issues"
-  },
+  "homepage": "https://github.com/bitjoo/aemsync",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gavoja/aemsync.git"
+    "url": "https://github.com/bitjoo/aemsync.git"
   },
   "main": "index.js",
   "dependencies": {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -10,7 +10,7 @@ const PLATFORMS = ['win32', 'darwin']
 
 class Watcher {
   isFallback() {
-      return PLATFORMS.indexOf(process.platform) !== -1
+      return PLATFORMS.indexOf(process.platform) === -1
   }
 
   watch (workingDir, exclude, callback) {

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -9,8 +9,12 @@ const chalk = require('chalk')
 const PLATFORMS = ['win32', 'darwin']
 
 class Watcher {
+  isFallback() {
+      return PLATFORMS.indexOf(process.platform) !== -1
+  }
+
   watch (workingDir, exclude, callback) {
-    if (PLATFORMS.indexOf(process.platform) !== -1) {
+    if (!this.isFallback()) {
       this.watchFolder(workingDir, true, exclude, callback)
     } else {
       log.info(`Scanning folder (may take a while): ${chalk.yellow(workingDir)} ...`)
@@ -50,7 +54,9 @@ class Watcher {
         if (exclude && anymatch(exclude, localPath)) {
           return
         }
-
+        if (this.isFallback()) {
+            this.watchFolderFallback(localPath, exclude, callback)
+        }
         callback(localPath)
       })
     })


### PR DESCRIPTION
Have a quick fix to create new watcher for created folders.